### PR TITLE
Itargetable

### DIFF
--- a/NavBallDockingAlignmentIndicator.cs
+++ b/NavBallDockingAlignmentIndicator.cs
@@ -119,13 +119,13 @@ public class NavBallDockingAlignmentIndicator : MonoBehaviour
 					Transform selfTransform = FlightGlobals.ActiveVessel.ReferenceTransform;
 
 					//indicator position
-					Vector3 targetPortOutVector = targetTransform.up.normalized;
+					Vector3 targetPortOutVector = targetTransform.forward.normalized;
 					Vector3 targetPortInVector = -targetPortOutVector;
 					Vector3 rotatedTargetPortInVector = navBallBehaviour.attitudeGymbal * targetPortInVector;
 					indicator.transform.localPosition = rotatedTargetPortInVector * navBallBehaviour.progradeVector.localPosition.magnitude;
 
 					//indicator rotation
-					Vector3 v1 = Vector3.Cross(selfTransform.up, targetTransform.forward);
+					Vector3 v1 = Vector3.Cross(selfTransform.up, -targetTransform.up);
 					Vector3 v2 = Vector3.Cross(selfTransform.up, selfTransform.forward);
 					float ang = Vector3.Angle(v1, v2);
 					if(Vector3.Dot(selfTransform.up, Vector3.Cross(v1, v2)) < 0) {

--- a/NavBallDockingAlignmentIndicator.cs
+++ b/NavBallDockingAlignmentIndicator.cs
@@ -113,9 +113,9 @@ public class NavBallDockingAlignmentIndicator : MonoBehaviour
 
 		if(FlightGlobals.fetch != null) {
 			if(FlightGlobals.fetch.VesselTarget != null) {
-				if(FlightGlobals.fetch.VesselTarget is ModuleDockingNode) {
-					ModuleDockingNode targetPort = FlightGlobals.fetch.VesselTarget as ModuleDockingNode;
-					Transform targetTransform = targetPort.transform;
+				if(FlightGlobals.fetch.VesselTarget.GetTargetingMode() == VesselTargetModes.DirectionVelocityAndOrientation) {
+					ITargetable targetPort = FlightGlobals.fetch.VesselTarget;
+					Transform targetTransform = targetPort.GetTransform();
 					Transform selfTransform = FlightGlobals.ActiveVessel.ReferenceTransform;
 
 					//indicator position


### PR DESCRIPTION
This is a set of patches to allow the navball docking alignment indicator to work with any part that provides target orientation, not just docking ports. One example (the only one I know of, actually) is Extraplanetary Launchpads' recycling bins (though they currently use the wrong transform).

As a side effect, this fixes the alignment indicator to work properly with in-line the docking port.
